### PR TITLE
feat(auth): 로그인 성공 페이지 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.idea/**

--- a/src/App.js
+++ b/src/App.js
@@ -30,7 +30,8 @@ import ResumeListPage from "./pages/resume/ResumeListPage";
 import SellerRegisterPage from "./pages/member/SellerRegisterPage";
 import SelfPromotionUpsertPage from "./pages/selfPromotion/SelfPromotionUpsertPage"; // Create/Update 공용
 import TagManagementPage from "./pages/tag/TagManagementPage";
-import MemberRatingPage from "./pages/rating/MemberRatingPage"; // 다른 회원 평가도 로그인 후 가능
+import MemberRatingPage from "./pages/rating/MemberRatingPage";
+import LoginSuccessPage from "./pages/LoginSuccessPage"; // 다른 회원 평가도 로그인 후 가능
 
 function App() {
   return (
@@ -50,6 +51,7 @@ function App() {
               />
               <Route path="/login" element={<LoginPage />} />
               <Route path="/login/need-signed-up" element={<SignUpPage />} />
+              <Route path="/login/success" element={<LoginSuccessPage />} />
               <Route path="/fail" element={<FailPage />} />
               <Route
                 path="/search/commissions"

--- a/src/pages/LoginSuccessPage.js
+++ b/src/pages/LoginSuccessPage.js
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import axios from "axios";
+import { useAuth } from "../components/AuthContext";
+import { REISSUE_URL } from "../constants";
+
+const LoginSuccessPage = () => {
+  const navigate = useNavigate();
+  const { updateToken } = useAuth();
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const reissueToken = async () => {
+      try {
+        // Show loading state
+        console.log("Requesting new access token...");
+        
+        // Make POST request to /reissue endpoint
+        const response = await axios.post(REISSUE_URL, {}, { withCredentials: true });
+        
+        // Extract the new access token from the response header
+        const newAccessToken = response.headers["authorization"]?.replace("Bearer ", "");
+        
+        if (!newAccessToken) {
+          throw new Error("No access token received from server");
+        }
+        
+        console.log("Successfully received new access token");
+        
+        // Remove old access token and store the new one
+        localStorage.removeItem("accessToken");
+        updateToken(newAccessToken);
+        
+        // Redirect to root page
+        navigate("/", { replace: true });
+      } catch (err) {
+        console.error("Failed to reissue token:", err);
+        setError("Failed to authenticate. Please try logging in again.");
+      }
+    };
+
+    reissueToken();
+  }, [navigate, updateToken]);
+
+  if (error) {
+    return (
+      <div className="flex justify-center items-center min-h-screen bg-gray-100">
+        <div className="bg-white p-8 rounded-lg shadow-md max-w-md w-full">
+          <h2 className="text-2xl font-bold text-red-600 mb-4">Authentication Error</h2>
+          <p className="text-gray-700 mb-4">{error}</p>
+          <button
+            onClick={() => navigate("/login")}
+            className="w-full bg-blue-600 text-white py-2 px-4 rounded hover:bg-blue-700 transition-colors"
+          >
+            Go to Login
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex justify-center items-center min-h-screen bg-gray-100">
+      <div className="bg-white p-8 rounded-lg shadow-md max-w-md w-full text-center">
+        <h2 className="text-2xl font-bold text-gray-800 mb-4">Authentication in progress...</h2>
+        <p className="text-gray-600 mb-4">Please wait while we complete your authentication.</p>
+        <div className="flex justify-center">
+          <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-blue-600"></div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LoginSuccessPage;


### PR DESCRIPTION
회원 가입을 진행한 멤버가 로그인 성공 시

연결될 로그인 성공 페이지 추가.

[AccessToken 삭제]
<img width="1118" height="501" alt="image" src="https://github.com/user-attachments/assets/e5ae738c-4958-4cba-aa0e-816e4ab85529" />

[AccessToken 삭제 확인]
<img width="1086" height="447" alt="image" src="https://github.com/user-attachments/assets/7b93383c-987a-4969-b176-2a471a38ee71" />

[로그인시 다시 AccessToken 생성 확인]
<img width="1201" height="323" alt="image" src="https://github.com/user-attachments/assets/6b00302e-19aa-48d8-abf7-a897e3d9fdbe" />

